### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-results-1-19-watcher

### DIFF
--- a/.konflux/dockerfiles/watcher.Dockerfile
+++ b/.konflux/dockerfiles/watcher.Dockerfile
@@ -25,8 +25,9 @@ COPY --from=builder /tmp/openshift-pipelines-results-watcher ${KO_APP}/watcher
 COPY head ${KO_DATA_PATH}/HEAD
 
 LABEL \
-      com.redhat.component="openshift-pipelines-results-watcher-rhel-8-container" \
-      name="openshift-pipelines/pipelines-results-watcher-rhel8" \
+      com.redhat.component="openshift-pipelines-results-watcher-rhel-9-container" \
+      name="openshift-pipelines/pipelines-results-watcher-rhel9" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.19::el9" \
       version="${CI_CONTAINER_VERSION}" \
       summary="Red Hat OpenShift Pipelines Results Watcher" \
       maintainer="pipelines-extcomm@redhat.com" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
