### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-results-1-16-retention-policy-agent

### DIFF
--- a/.konflux/dockerfiles/retention-policy-agent.Dockerfile
+++ b/.konflux/dockerfiles/retention-policy-agent.Dockerfile
@@ -27,6 +27,7 @@ LABEL \
       com.redhat.component="openshift-pipelines-results-retention-policy-agent-rhel8-container" \
       name="openshift-pipelines/pipelines-results-retention-policy-agent-rhel8" \
       version=$VERSION \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.16::el8" \
       summary="Red Hat OpenShift Pipelines Results retention policy agent" \
       maintainer="pipelines-extcomm@redhat.com" \
       description="Red Hat OpenShift Pipelines Results retention policy agent" \


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
