### PR TITLE
chore(KONFLUX-6210): fix and set name and cpe label for tektoncd-results-1-14-watcher

### DIFF
--- a/.konflux/dockerfiles/watcher.Dockerfile
+++ b/.konflux/dockerfiles/watcher.Dockerfile
@@ -34,7 +34,8 @@ LABEL \
       description="Red Hat OpenShift Pipelines Results Watcher" \
       io.openshift.tags="results,tekton,openshift,watcher"  \
       io.k8s.description="Red Hat OpenShift Pipelines Results Watcher" \
-      io.k8s.display-name="Red Hat OpenShift Pipelines Results Watcher"
+      io.k8s.display-name="Red Hat OpenShift Pipelines Results Watcher" \
+      cpe="cpe:/a:redhat:openshift_pipelines:1.14::el8"
 
 RUN groupadd -r -g 65532 nonroot && useradd --no-log-init -r -u 65532 -g nonroot nonroot
 USER 65532


### PR DESCRIPTION
For https://issues.redhat.com/browse/KONFLUX-6210, clair needs access to a name and cpe label that it can use to look up the image in VEX statements.

See also release-engineering/rhtap-ec-policy#149

Signed-off-by: Ralph Bean <rbean@redhat.com>
Assisted-by: Gemini
