### PR TITLE
chore: bump version labels to 1.15.4

### DIFF
--- a/.konflux/dockerfiles/api.Dockerfile
+++ b/.konflux/dockerfiles/api.Dockerfile
@@ -15,7 +15,7 @@ RUN go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat HEAD)'" -mod=vend
     ./cmd/api
 
 FROM $RUNTIME
-ARG VERSION=results-api-1.15.3
+ARG VERSION=results-api-1.15.4
 
 ENV API=/usr/local/bin/results-api \
     KO_APP=/ko-app \

--- a/.konflux/dockerfiles/watcher.Dockerfile
+++ b/.konflux/dockerfiles/watcher.Dockerfile
@@ -16,7 +16,7 @@ RUN go build -ldflags="-X 'knative.dev/pkg/changeset.rev=$(cat HEAD)'" -mod=vend
 RUN /bin/sh -c 'echo $CI_RESULTS_UPSTREAM_COMMIT > /tmp/HEAD'
 
 FROM $RUNTIME
-ARG VERSION=results-watcher-1.15.3
+ARG VERSION=results-watcher-1.15.4
 
 ENV WATCHER=/usr/local/bin/openshift-pipelines-results-watcher \
     KO_APP=/ko-app \


### PR DESCRIPTION
Bump ARG VERSION from 1.15.3 to 1.15.4 in api.Dockerfile and watcher.Dockerfile.