### PR TITLE
[release-v1.15.x] Fix Dockerfiles and remove empty RPM lockfile

### DIFF
--- a/.konflux/rpms/rpms.in.yaml
+++ b/.konflux/rpms/rpms.in.yaml
@@ -1,9 +1,8 @@
 contentOrigin:
   repofiles:
     - ./ubi.repo
-packages: [shadow-utils]
+packages: []
 arches:
-  # The list of architectures
   - aarch64
   - x86_64
   - ppc64le

--- a/.konflux/rpms/rpms.lock.yaml
+++ b/.konflux/rpms/rpms.lock.yaml
@@ -1,20 +1,4 @@
 ---
 lockfileVersion: 1
 lockfileVendor: redhat
-arches:
-- arch: aarch64
-  packages: []
-  source: []
-  module_metadata: []
-- arch: ppc64le
-  packages: []
-  source: []
-  module_metadata: []
-- arch: s390x
-  packages: []
-  source: []
-  module_metadata: []
-- arch: x86_64
-  packages: []
-  source: []
-  module_metadata: []
+arches: []


### PR DESCRIPTION
## Summary
- Fix empty RPM lockfile: clear `rpms.in.yaml` packages and set `arches: []` in lockfile

## Root cause
`hermeto 0.55.0` rejects the RPM lockfile:
```
InvalidLockfileFormat: lockfile '.konflux/rpms/rpms.lock.yaml' format is not valid:
('arches', 0): Value error, At least one field ('packages', 'source') must be set in every arch.
```
The `rpms.in.yaml` requested `shadow-utils` but the lockfile was never resolved. Since the Dockerfiles use `ubi8/ubi` (not `ubi-minimal`), `shadow-utils` is already available — no RPM prefetch needed.

Note: `retention-policy-agent` component also fails (missing Dockerfile + source code on `release-v1.15.x`). This is a separate pre-existing issue — the component was added in a newer version and shouldn't be in the 1.15 Konflux config.

## Test plan
- [x] Konflux PR pipeline passes for api and watcher (prefetch-dependencies succeeds)
- [ ] retention-policy-agent failure is expected (pre-existing, unrelated)